### PR TITLE
README: note merge into LinuxCNC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 linuxcnc-huanyang-vfd
 =====================
 
+This Huanyang VFD driver has been merged into LinuxCNC as of
+2.7.0.  It is no longer necessary to compile it as a stand-alone
+external component.  Details on the integration are here:
+http://linuxcnc.org/docs/2.7/html/getting-started/updating-linuxcnc.html#_huanyang_vfd
+
+
+## History
+
 A user space component for controlling a huanyang spindle inverter with linuxcnc.
 The component was developed by S. Alford and published at http://www.cnczone.com/forums/phase-converters/91847-huanyang-vfd-rs485-modbus-3.html#post704008http://www.cnczone.com/forums/phase-converters/91847-huanyang-vfd-rs485-modbus-3.html#post704008
 Some changes were contributed to fix problems with the rebranding of emc2 to linuxcnc.


### PR DESCRIPTION
This updates the README to note that this driver has been merged into LinuxCNC. We've had users not know that it's been merged and get into trouble trying to compile it themselves.
